### PR TITLE
replaced eval with much safter ast literal eval

### DIFF
--- a/flumelogger/handler.py
+++ b/flumelogger/handler.py
@@ -54,7 +54,6 @@ class FlumeHandler(logging.Handler):
     def emit(self, record):
         try:
             self.body = self.format(record)
-            print 'am here', self.body
             try:
                 msg = ast.literal_eval(self.body)
             except:


### PR DESCRIPTION
This should remove the severe security risk of evaling data that is possibly user provided. It uses the ast module from the standard library.
