### PR TITLE
respect logging.raiseExceptions behavior

### DIFF
--- a/flumelogger/eventserver.py
+++ b/flumelogger/eventserver.py
@@ -35,6 +35,6 @@ class FlumeEventServer(object):
 
             self.client.append(event)
         except Exception, tx:
-            print 'Thrift: %s' % tx
             self.client = None
             self.transport.close()
+            raise Exception('Thrift: %s' % tx)


### PR DESCRIPTION
Users should be able to configure `logging.raiseExceptions` to control whether or not exceptions should be raised when flumelogger was unable to emit the message to flume.

The current implementation silently discards such exceptions which bypasses the call to `handleError` on the `emit` function from the FlumeHandler class.