### PR TITLE
add support for batch append operations

### DIFF
--- a/flumelogger/eventserver.py
+++ b/flumelogger/eventserver.py
@@ -34,6 +34,17 @@ class FlumeEventServer(object):
                 self.connect()
 
             self.client.append(event)
+        except KeyError, tx:
+            self.client = None
+            self.transport.close()
+            raise Exception('Thrift: %s' % tx)
+
+    def append_batch(self, events):
+        try:
+            if self.client is None:
+                self.connect()
+
+            self.client.appendBatch(events)
         except Exception, tx:
             self.client = None
             self.transport.close()


### PR DESCRIPTION
...when passing a list to the logger !

quick benchmark : 
````
    10000 msg in 37.5808801651 s = 266.0 msg/s
    10000 bulked msg in 1.53806114197 s = 6501.0 msg/s
````

@lsjostro I'm disappointed by the poor throughput on a msg/msg basis. Do you have some insight or tips about ways to get a better performance ?

PS: I see that `# Autogenerated by Thrift Compiler (0.9.0)` on the ThriftSourceProtocol.py file, would you care to update it with the newer Thrift 0.9.3 maybe ?