### PR TITLE
fix incorrect error handling on batch append

### DIFF
--- a/flumelogger/handler.py
+++ b/flumelogger/handler.py
@@ -115,5 +115,12 @@ class FlumeHandler(logging.Handler):
             self.eventserver.append_batch(events)
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except Exception as err:
+            record = logging.LogRecord(name=records.name,
+                                       level=records.levelno,
+                                       pathname=records.pathname,
+                                       lineno=records.lineno,
+                                       msg=err,
+                                       args=records.args,
+                                       exc_info=records.exc_info)
             self.handleError(record)


### PR DESCRIPTION
else it fails horribly with a `UnboundLocalError: local variable 'record' referenced before assignment`