### PR TITLE
Fix nodes unicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ Python library for sending log events to flume. Support both FlumeNG and FlumeOG
 
 ```
 >>> [...]
->>> fh.eventserver.reconnect()
+>>> fh.reconnect()
 ```

--- a/flumelogger/eventserver.py
+++ b/flumelogger/eventserver.py
@@ -40,7 +40,6 @@ class FlumeEventServer(object):
         self.debug = debug
 
         # NOTE: parse the host URI.
-        self.active_nodes = set()
         for entity in self.host:
             self.default_nodes = split_hosts(entity, self.port)
             log_debug("nodes available {}".format(self.default_nodes), debug=self.debug)
@@ -114,7 +113,8 @@ class FlumeEventServer(object):
         """
         log_debug("add {} to the active nodes".format(node), debug=self.debug)
         self.open_connections[node] = {'client': client, 'transport': transport}
-        self.active_nodes.append(node)
+        if node not in self.active_nodes:
+            self.active_nodes.append(node)
         self.cycle_nodes = cycle(self.active_nodes)
 
     def __enter__(self):

--- a/flumelogger/eventserver.py
+++ b/flumelogger/eventserver.py
@@ -161,7 +161,6 @@ class FlumeEventServer(object):
                     self._add_node(node=node, client=client, transport=transport)
             except ConnectionFailure as e:
                 log_debug('failed to reconnect to {}'.format(node), debug=self.debug)
-                continue
 
     def append(self, event, client):
         try:

--- a/flumelogger/handler.py
+++ b/flumelogger/handler.py
@@ -44,6 +44,7 @@ class FlumeHandler(logging.Handler):
                                             type=self.type,
                                             reuse=self.reuse,
                                             debug=self.debug)
+        self.reconnect = self.eventserver.reconnect
 
     def event_ng(self, body, headers):
         return ThriftFlumeNGEvent(headers=headers, body=body)

--- a/tests/test_eventserver.py
+++ b/tests/test_eventserver.py
@@ -77,6 +77,19 @@ class TestEventServer(unittest.TestCase):
         eventserver._remove_node(node=('localhost', 7777))
         self.assertListEqual([('localhost', 7777)], eventserver.default_nodes)
 
+    def test_active_nodes_unicity(self):
+        """ Ensure the nodes unicity in the actives nodes list.
+
+            Fix:
+                2015-11-27: we use a list and we don't check the presence of the same node into the list.
+        """
+        from flumelogger.eventserver import FlumeEventServer
+        from flumelogger.errors import ServerSelectionError
+
+        eventserver = FlumeEventServer(host='localhost:7777,localhost:8888')
+        eventserver._remove_node(node=('localhost', 7777))
+        self.assertEqual([('localhost', 8888)], eventserver.active_nodes)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello,
To avoid multiple PR, i compact some fix/improvements.

### Fix the unicity into the active nodes
Regression bug.

### Remove useless [...]
Useless instruction.

### Expose the reconnect method [...]
Improve the public API.
Avoid to use the event server object throught the handler.

Sorry for the bugs btw :smirk_cat: 
Thanks
