### PR TITLE
Thrift errors are not returned to the client

### DIFF
--- a/flumelogger/eventserver.py
+++ b/flumelogger/eventserver.py
@@ -165,14 +165,14 @@ class FlumeEventServer(object):
 
     def append(self, event, client):
         try:
-            client.append(event)
+            return client.append(event)
         except Exception as e:
             self._remove_node(node=self.current_node)
             raise OperationFailure(e)
 
     def append_batch(self, events, client):
         try:
-            client.appendBatch(events)
+            return client.appendBatch(events)
         except Exception as e:
             self._remove_node(node=self.current_node)
             raise OperationFailure(e)

--- a/flumelogger/handler.py
+++ b/flumelogger/handler.py
@@ -102,7 +102,9 @@ class FlumeHandler(logging.Handler):
 
             # send event
             with self.eventserver as client:
-                self.eventserver.append(tevent, client)
+                result = self.eventserver.append(tevent, client)
+                if result != 0:
+                    raise Exception('Thrift error {}'.format(result))
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:
@@ -131,7 +133,9 @@ class FlumeHandler(logging.Handler):
 
             # send events
             with self.eventserver as client:
-                self.eventserver.append_batch(events, client)
+                result = self.eventserver.append_batch(events, client)
+                if result != 0:
+                    raise Exception('Thrift error {}'.format(result))
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:


### PR DESCRIPTION
so it does not raise any exception.

This is very bad because this can lead to the client wrongly think that the Thrift transaction succeeded while it didnt...
